### PR TITLE
Fix bug causing invalid id in SignedTransaction

### DIFF
--- a/src/chain/transaction.ts
+++ b/src/chain/transaction.ts
@@ -170,6 +170,19 @@ export class SignedTransaction extends Transaction {
     /** Context-free action data, for each context-free action, there is an entry here. */
     @Struct.field('bytes[]') declare context_free_data: Bytes[]
 
+    /** The transaction without the signatures. */
+    get transaction(): Transaction {
+        return Transaction.from({
+            ...this,
+            signatures: undefined,
+            context_free_data: undefined,
+        })
+    }
+
+    get id(): Checksum256 {
+        return this.transaction.id
+    }
+
     static from(object: SignedTransactionType) {
         return super.from({
             signatures: [],

--- a/test/chain.ts
+++ b/test/chain.ts
@@ -17,6 +17,7 @@ import {
     PermissionLevel,
     PublicKey,
     Signature,
+    SignedTransaction,
     Struct,
     TimePoint,
     TimePointSec,
@@ -167,6 +168,14 @@ suite('chain', function () {
         )
         const transfer = transaction.actions[0].decodeData(Transfer)
         assert.equal(String(transfer.from), 'foo')
+
+        const signed = SignedTransaction.from({
+            ...transaction,
+            signatures: [
+                'SIG_K1_KdNTcLLSyzUFC4AdMxEDn58X8ZN368euanvet4jucUdSPXvLkgsG32tpcqVvnDR9Xv1f7HsTm6kocjeZzFGvUSc2yCbdEA',
+            ],
+        })
+        assert.equal(String(signed.id), String(transaction.id))
     })
 
     test('any transaction', function () {


### PR DESCRIPTION
Any subclass of Transaction must re-implement .id if it extends its ABI since the parent class implementation encodes and hashes itself to obtain the id