### PR TITLE
ESLint: Restrict Imports 'chai-*' not allowed

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -20,6 +20,12 @@
                 "ignoreDeclarationSort": true
             }
         ],
+        "no-restricted-imports": ["ERROR", {
+            "patterns": [{
+                "group": ["chai-*"],
+                "message": "Use of additional chai packages not allowed. Please restrict testing to chai"
+            }]
+        }],
         "@typescript-eslint/explicit-module-boundary-types": "off",
         "@typescript-eslint/no-explicit-any": "off",
         "@typescript-eslint/no-namespace": "off",


### PR DESCRIPTION
Updated ESLint with a rule to error on any imports. 

NOTE: This pull request was generated off a testing library issue. May want to extending `make check` to cover `test/**/*.ts`

Standard TS ESLint comes with rule to restrict imports. Used that rule to restrict any imports matching 'chia-*'.  Rules may be extended with additional patterns in the future. 
<img width="1005" alt="Screen Shot 2022-10-31 at 8 37 37 AM" src="https://user-images.githubusercontent.com/6685407/199076878-895dee55-3688-4903-b7af-135a32ab78a5.png">


